### PR TITLE
Update SignUp.vue to correct free trial access length

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
@@ -68,7 +68,7 @@
                   Free Trial
                 </div>
                 <div class="signup__rate__text">
-                  Get access for 22 days
+                  Get access for 30 days
                 </div>
               </div>
               <div class="signup__content">


### PR DESCRIPTION
## Description:
- **What's changed?** The correct Okta free trial access term is 30 days, not 22. The Sign Up page was updated to reflect this.

### Resolves:

* [OKTA-634186](https://oktainc.atlassian.net/browse/OKTA-634186)
